### PR TITLE
Fix flyout height. Prevent scrollbars from appearing while animating

### DIFF
--- a/kwc-blockly-toolbox.html
+++ b/kwc-blockly-toolbox.html
@@ -52,7 +52,6 @@ Example:
                 cursor: pointer;
                 padding: 2px 32px 3px 12px;
                 transition: border-color linear 100ms;
-                height: 32px;
             }
             button.category>* {
                 display: inline-block;
@@ -286,6 +285,7 @@ Example:
                         this.$.mask.style.display = 'block';
                         this.$.mask.style.top = `${rect.top + rect.height}px`;
                         duration = size.height / 3;
+                        this.style.overflowY = 'hidden';
                         for (let i = 0; i < buttons.length; i++) {
                             if (over) {
                                 buttons[i].animate({
@@ -303,6 +303,7 @@ Example:
                             duration,
                             fill: 'forwards'
                         }).onfinish = () => {
+                            this.style.overflowY = 'auto';
                             this.$.mask.style.display = 'none';
                         };
                     };


### PR DESCRIPTION
https://trello.com/c/Pw7V457b/1217-minecraft-block-overhang-in-toolbox-prevents-category-below-being-opened