### PR TITLE
Fixing the toolbox glitch on iOS

### DIFF
--- a/kwc-blockly-toolbox.html
+++ b/kwc-blockly-toolbox.html
@@ -257,6 +257,9 @@ Example:
                     target = e.target,
                     index = e.model.get('index');
 
+                e.stopPropagation();
+                e.preventDefault();
+                
                 if (category.type === 'separator') {
                     return;
                 }


### PR DESCRIPTION
It was due to the tap event being propagated to the flyout element which added a block straight away and closed the flyout.