### PR TITLE
Fix issue where block is added to workspace on simple click

### DIFF
--- a/import.js
+++ b/import.js
@@ -6,6 +6,7 @@ import './override/core/css.js';
 import './override/core/connection.js';
 import './override/core/block.js';
 import './override/core/block_svg.js';
+import './override/core/gesture.js';
 import './override/core/scrollbar.js';
 import './override/core/block_render_svg.js';
 import './override/core/workspace_svg.js';

--- a/kwc-blockly-flyout.js
+++ b/kwc-blockly-flyout.js
@@ -301,8 +301,6 @@ class KwcBlocklyFlyout extends PolymerElement {
         this._listeners = this._listeners || [];
         this._listeners.push(Blockly.bindEvent_(root, 'mousedown', null, this._blockMouseDown(block)));
         this._listeners.push(Blockly.bindEvent_(rect, 'mousedown', null, this._blockMouseDown(block)));
-        this._listeners.push(Blockly.bindEvent_(root, 'mouseup', null, this._blockMouseUp(block)));
-        this._listeners.push(Blockly.bindEvent_(rect, 'mouseup', null, this._blockMouseUp(block)));
         this._listeners.push(Blockly.bindEvent_(root, 'mouseover', block, block.addSelect));
         this._listeners.push(Blockly.bindEvent_(root, 'mouseout', block, block.removeSelect));
         this._listeners.push(Blockly.bindEvent_(rect, 'mouseover', block, block.addSelect));
@@ -331,14 +329,6 @@ class KwcBlocklyFlyout extends PolymerElement {
                 this.targetWorkspace._gesture = gesture;
             }
         };
-    }
-    _blockMouseUp(block) {
-        return (e) => {
-            const gesture = this.targetWorkspace.getGesture(e);
-            if (gesture) {
-                gesture.cancel();
-            }
-        }
     }
     createBlock(originBlock) {
         let block;

--- a/kwc-blockly-flyout.js
+++ b/kwc-blockly-flyout.js
@@ -301,6 +301,8 @@ class KwcBlocklyFlyout extends PolymerElement {
         this._listeners = this._listeners || [];
         this._listeners.push(Blockly.bindEvent_(root, 'mousedown', null, this._blockMouseDown(block)));
         this._listeners.push(Blockly.bindEvent_(rect, 'mousedown', null, this._blockMouseDown(block)));
+        this._listeners.push(Blockly.bindEvent_(root, 'mouseup', null, this._blockMouseUp(block)));
+        this._listeners.push(Blockly.bindEvent_(rect, 'mouseup', null, this._blockMouseUp(block)));
         this._listeners.push(Blockly.bindEvent_(root, 'mouseover', block, block.addSelect));
         this._listeners.push(Blockly.bindEvent_(root, 'mouseout', block, block.removeSelect));
         this._listeners.push(Blockly.bindEvent_(rect, 'mouseover', block, block.addSelect));
@@ -329,6 +331,14 @@ class KwcBlocklyFlyout extends PolymerElement {
                 this.targetWorkspace._gesture = gesture;
             }
         };
+    }
+    _blockMouseUp(block) {
+        return (e) => {
+            const gesture = this.targetWorkspace.getGesture(e);
+            if (gesture) {
+                gesture.cancel();
+            }
+        }
     }
     createBlock(originBlock) {
         let block;

--- a/override/core/gesture.js
+++ b/override/core/gesture.js
@@ -1,0 +1,20 @@
+/**
+ * Execute a block click.
+ * @private
+ */
+Blockly.Gesture.prototype.doBlockClick_ = function() {
+    // Block click in an autoclosing flyout.
+    if (this.flyout_ && this.flyout_.autoClose) {
+      if (!this.targetBlock_.disabled) {
+        if (!Blockly.Events.getGroup()) {
+          Blockly.Events.setGroup(true);
+        }
+      }
+    } else {
+      // Clicks events are on the start block, even if it was a shadow.
+      Blockly.Events.fire(
+          new Blockly.Events.Ui(this.startBlock_, 'click', undefined, undefined));
+    }
+    this.bringBlockToFront_();
+    Blockly.Events.setGroup(false);
+  };


### PR DESCRIPTION
In the standard use case, `mouseup` will not fire before a block is actually added. It fires `after` the block is created, but before the block is moved and dropped on the workspace.

Therefore, cancelling the gesture on mouseup prevents side effects. In our case, the creation of the "undropped" block under the toolbox. This behavior is modeled on similar safeguards already present in `workspace_svg.js`.

(missing access to jenkins - build fails, but I have played the patch against a live version of `kit-app-ui` and tested it).