### PR TITLE
SX-861: used bindEventWithChecks_ as per blockly repo

### DIFF
--- a/kwc-blockly-flyout.js
+++ b/kwc-blockly-flyout.js
@@ -310,8 +310,8 @@ class KwcBlocklyFlyout extends PolymerElement {
     }
     _addBlockListeners(root, block, rect) {
         this._listeners = this._listeners || [];
-        this._listeners.push(Blockly.bindEvent_(root, 'mousedown', null, this._blockMouseDown(block)));
-        this._listeners.push(Blockly.bindEvent_(rect, 'mousedown', null, this._blockMouseDown(block)));
+        this._listeners.push(Blockly.bindEventWithChecks_(root, 'mousedown', null, this._blockMouseDown(block)));
+        this._listeners.push(Blockly.bindEventWithChecks_(rect, 'mousedown', null, this._blockMouseDown(block)));
         this._listeners.push(Blockly.bindEvent_(root, 'mouseover', block, block.addSelect));
         this._listeners.push(Blockly.bindEvent_(root, 'mouseout', block, block.removeSelect));
         this._listeners.push(Blockly.bindEvent_(rect, 'mouseover', block, block.addSelect));


### PR DESCRIPTION
In blockly repo they use `Blockly.bindEventWithChecks_` instead of `Blockly.bindEvent_` with mouseDown events. So switched in our codebase and seems to fix the issue.