### PR TITLE
fix: only scroll when needed

### DIFF
--- a/kwc-blockly-flyout.js
+++ b/kwc-blockly-flyout.js
@@ -11,7 +11,7 @@ class KwcBlocklyFlyout extends PolymerElement {
             <style>
                 :host {
                     display: block;
-                    overflow-y: scroll;
+                    overflow-y: auto;
                 }
                 .injectionDiv {
                     position: relative;


### PR DESCRIPTION
Note: tested on Kano World (which is fine); I've had difficulty testing on the iOS app because of Mac update issues. Is anyone able to test this on an iOS 10 iPad?