### PR TITLE
Close toolbox flyout if its toolbox item is no longer available.

### DIFF
--- a/kwc-blockly-toolbox.js
+++ b/kwc-blockly-toolbox.js
@@ -221,6 +221,9 @@ class KwcBlocklyToolbox extends PolymerElement {
         this._metrics = this.getBoundingClientRect();
     }
     _toolboxDomChanged() {
+        if (this.opened && !this.toolbox.find(tool => tool.id === this.currentId)) {
+            this.close();
+        }
         this._updateMetrics();
         if (this.targetWorkspace) {
             this.targetWorkspace.resize();
@@ -364,6 +367,7 @@ class KwcBlocklyToolbox extends PolymerElement {
             }
             this.$.flyout.style.display = 'block';
             this.prevSelected = this.currentSelected;
+            this.currentId = category.id;
             this.currentSelected = index;
             this.currentToolbox = category.blocks;
             this.set(`toolbox.${this.currentSelected}.selected`, true);
@@ -378,6 +382,7 @@ class KwcBlocklyToolbox extends PolymerElement {
                 type: Blockly.Events.CLOSE_FLYOUT,
             };
             this.prevSelected = this.currentSelected;
+            this.currentId = undefined;
             this.currentSelected = undefined;
             this.currentToolbox = undefined;
             this.updateStyles({


### PR DESCRIPTION
This PR is a proposed fix for #66. 

It adds a new `currentId` property to the `KwcBlocklyToolbox` component to track the ID of the currently selected toolbox. When the underlying toolbox data is modified, the `toolboxDomChanged` event checks to see if the currently selected toolbox element still exists by comparing `currentId` to the list of available toolboxes. If it was deleted as part of the toolbox update then `KwcBlocklyToolbox.close()` is called to force-close the flyout and tidy up.

A new property was necessary because `selectedIndex` isn't reliable when the part being removed isn't the last item in the list.

