### PR TITLE
Bugfix: Issue 69

### DIFF
--- a/override/core/block_render_svg.js
+++ b/override/core/block_render_svg.js
@@ -593,11 +593,11 @@ Blockly.BlockSvg.prototype.renderDrawRight_ = function(pathObject, inputRows, ic
       }
       steps.push('v', this.getPaddingY());
       steps.push(Blockly.BlockSvg.TAB_PATH_DOWN_BLOCK);
-      steps.push('v', -this.getPaddingY());
       var nextRow = inputRows[y + 1];
       if (y === inputRows.length - 1 || nextRow && nextRow.type === Blockly.NEXT_STATEMENT) {
           v -= Blockly.BlockSvg.CORNER_RADIUS;
       }
+      v -= this.getPaddingY();
       steps.push('v', v);
       if (this.RTL) {
         // Highlight around back of tab.

--- a/override/core/block_render_svg.js
+++ b/override/core/block_render_svg.js
@@ -734,8 +734,8 @@ Blockly.BlockSvg.prototype.renderDrawRight_ = function(pathObject, inputRows, ic
       connectionX = this.RTL ? -cursorX : cursorX + 1;
       input.connection.setOffsetInBlock(connectionX, cursorY + 1);
 
-      // 2 corners were added to the path, but the connection offset needs to be computed without them
-      cursorY += Blockly.BlockSvg.CORNER_RADIUS * 2;
+      // 3 corners were added to the path, but the connection offset needs to be computed without them
+      cursorY += Blockly.BlockSvg.CORNER_RADIUS * 3;
 
       if (input.connection.isConnected()) {
         this.width = Math.max(this.width, inputRows.statementEdge +
@@ -750,10 +750,14 @@ Blockly.BlockSvg.prototype.renderDrawRight_ = function(pathObject, inputRows, ic
           highlightSteps.push('v', Blockly.BlockSvg.SEP_SPACE_Y - 1);
         }
         cursorY += Blockly.BlockSvg.SEP_SPACE_Y;
+      } else {
+        // The next statement will begin with a right corner radius. We need to
+        // account for the space it will take up or the next block will render
+        // in the wrong position.
+        steps.push('v', -Blockly.BlockSvg.CORNER_RADIUS);
       }
       if (y === inputRows.length - 1) {
         steps.push(Blockly.BlockSvg.BOTTOM_RIGHT_CORNER);
-        cursorY += Blockly.BlockSvg.CORNER_RADIUS;
       }
     }
     cursorY += row.height;


### PR DESCRIPTION
This PR addresses issue #69.

When drawing statement blocks for `if`/`elseif`/`else` conditions, the generated SVG path isn't correctly accounting for the height introduced by the extra radius corners drawn after the initial `if`.

**Before: — Note incorrect alignment on the `elseif` blocks:**
![Screen Shot 2020-01-29 at 20 46 48](https://user-images.githubusercontent.com/588665/73396031-80d47d80-42d8-11ea-8c53-1cc5a3f5b090.png)

**After: — Alignment on the `elseif` blocks is fixed:**
![Screen Shot 2020-01-29 at 20 39 59](https://user-images.githubusercontent.com/588665/73396040-83cf6e00-42d8-11ea-9652-4eb3eefdd8ca.png)

## Testing

Here's the Kano Code App I used to generate those screen grabs:

```js
{
  "source": "<xml xmlns=\"http://www.w3.org/1999/xhtml\"><variables><variable type=\"\" id=\"H)9p=QA65jPS@n~3[@qV\">item</variable></variables><block type=\"repeat_x_times\" id=\"36EjxSsr-*]y$;tnySPL\" x=\"149\" y=\"97\"><value name=\"N\"><shadow type=\"math_number\" id=\"Hjb)bb;,aT[Vu/zEREi*\"><field name=\"NUM\">1</field></shadow></value><statement name=\"DO\"><block type=\"repeat_x_times\" id=\"ihl0uGHGV(tA0CmvTSPa\"><value name=\"N\"><shadow type=\"math_number\" id=\"Sp_qV_U8ykGF?|j_KBX6\"><field name=\"NUM\">1</field></shadow></value><statement name=\"DO\"><block type=\"controls_if\" id=\"nlaCJ72sb!{%s[4Apg=6\"><field name=\"CONFIG\">{\"elseIfs\":2,\"else\":true}</field><value name=\"IF0\"><block type=\"logic_boolean\" id=\"+83rhYWXywAt0VVbBsvF\"><field name=\"BOOL\">TRUE</field></block></value><statement name=\"DO0\"><block type=\"unary\" id=\"u0pQ}i3t?[DOZW}+XA(*\"><field name=\"LEFT_HAND\" id=\"H)9p=QA65jPS@n~3[@qV\" variabletype=\"\">item</field><field name=\"OPERATOR\">+=</field><value name=\"RIGHT_HAND\"><shadow type=\"math_number\" id=\"]-7;5ujt~`t!w,Z@s0Pn\"><field name=\"NUM\">1</field></shadow></value><next><block type=\"draw_move_to\" id=\"aZutFmbfxT;3kbh1rPL+\"><value name=\"X\"><shadow type=\"math_number\" id=\"!|d|ED%%Mc=Gv1]?W!Qm\"><field name=\"NUM\">5</field></shadow></value><value name=\"Y\"><shadow type=\"math_number\" id=\"XcKqg)F%Dw3hUv@|*2TM\"><field name=\"NUM\">5</field></shadow></value></block></next></block></statement><value name=\"IF1\"><block type=\"logic_boolean\" id=\"N)IVdXAb9QWXm[TkrS2+\"><field name=\"BOOL\">TRUE</field></block></value><statement name=\"DO1\"><block type=\"unary\" id=\"_rY~2LOR*ZoOG[E{cy06\"><field name=\"LEFT_HAND\" id=\"H)9p=QA65jPS@n~3[@qV\" variabletype=\"\">item</field><field name=\"OPERATOR\">+=</field><value name=\"RIGHT_HAND\"><shadow type=\"math_number\" id=\"H@d}VjmbIQp*DW-+NZE^\"><field name=\"NUM\">1</field></shadow></value><next><block type=\"draw_move_to\" id=\"c)zZm@zS4-=on6FWPDp?\" inline=\"true\"><value name=\"X\"><shadow type=\"math_number\" id=\"!B4/PQs2pERiVlj*BmkJ\"><field name=\"NUM\">5</field></shadow></value><value name=\"Y\"><shadow type=\"math_number\" id=\"=Jsz]=/ROAU0)Q;N9ew4\"><field name=\"NUM\">5</field></shadow></value></block></next></block></statement><value name=\"IF2\"><block type=\"logic_compare\" id=\"h)4GT}WNEne(;QN0?kF?\"><field name=\"OP\">EQ</field><value name=\"A\"><block type=\"variables_get\" id=\"TSx0-$Y^rQ{+Xg!)Y*1m\"><field name=\"VAR\" id=\"H)9p=QA65jPS@n~3[@qV\" variabletype=\"\">item</field></block></value><value name=\"B\"><block type=\"math_random\" id=\"KD]e/},`/%FMTV8(3j*1\"><value name=\"MIN\"><shadow type=\"math_number\" id=\"WDz,qOD4ShLVG21H@ZGV\"><field name=\"NUM\">0</field></shadow></value><value name=\"MAX\"><shadow type=\"math_number\" id=\"fZGV!qh=NelQkU+U0/8!\"><field name=\"NUM\">10</field></shadow></value></block></value></block></value><statement name=\"DO2\"><block type=\"unary\" id=\"tukvyG|jLDo%3~0]QN?J\"><field name=\"LEFT_HAND\" id=\"H)9p=QA65jPS@n~3[@qV\" variabletype=\"\">item</field><field name=\"OPERATOR\">+=</field><value name=\"RIGHT_HAND\"><shadow type=\"math_number\" id=\"W,g0o8lBoI6$^jJEY5|A\"><field name=\"NUM\">1</field></shadow></value></block></statement><statement name=\"ELSE\"><block type=\"unary\" id=\"bXvB5|)kCFtRUl!GPKQC\"><field name=\"LEFT_HAND\" id=\"H)9p=QA65jPS@n~3[@qV\" variabletype=\"\">item</field><field name=\"OPERATOR\">+=</field><value name=\"RIGHT_HAND\"><shadow type=\"math_number\" id=\"NXm}bY+JJ1([^m|IuCN]\"><field name=\"NUM\">1</field></shadow></value></block></statement><next><block type=\"unary\" id=\"DM`qyNdC9}*b@TEfJ,c$\"><field name=\"LEFT_HAND\" id=\"H)9p=QA65jPS@n~3[@qV\" variabletype=\"\">item</field><field name=\"OPERATOR\">+=</field><value name=\"RIGHT_HAND\"><shadow type=\"math_number\" id=\"XLUs`G9**sn-5kZhS_d1\"><field name=\"NUM\">1</field></shadow></value></block></next></block></statement></block></statement></block></xml>",
  "code": "var item;\n\n\nfor (var i2 = 0; i2 < 1; i2++) {\n  for (var i = 0; i < 1; i++) {\n    if (true) {\n      item += 1;\n      ctx.moveTo(5, 5);\n    } else if (true) {\n      item += 1;\n      ctx.moveTo(5, 5);\n    } else if (item == math.random(0, 10)) {\n      item += 1;\n    } else {\n      item += 1;\n    }\n    item += 1;\n  }\n}\n",
  "parts": [],
  "profile": "default"
}
```
